### PR TITLE
Clear search results prior to searching again

### DIFF
--- a/assets/javascripts/functionDefintions.js
+++ b/assets/javascripts/functionDefintions.js
@@ -494,6 +494,7 @@ function clickSubmit() {
        }
        console.log(results)
      // console.log(getLowFareFlightOption(results))
+      $(".flightSearchResults").empty();
       getLowFareFlightOption(results).then(resp => displayFlightSearchResults(results,resp));
   })
   }


### PR DESCRIPTION
Previously if a 2nd search was attempted, it would just append to the previous results.
This PR fixes that issue by first clearing the results and creating the DOM elements again